### PR TITLE
ESLint test in chapter 1 is not working due to the order of extends 

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,9 @@
+<!-- Before creating your issue, please read the following:
+
+(1) Are you reporting a bug in the code? 
+If yes, please proceed with creating an issue.
+
+(2) Are you asking a general question or sharing a suggestion about the code or our books? 
+If yes, please create a new discussion item: https://github.com/builderbook/builderbook/discussions 
+
+-->

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,7 +1,0 @@
-<!-- Before creating your issue, please read the following:
-
-(1) To report a bug in the code, please proceed with creating an issue.
-
-(2) To ask a general question or share a suggestion about the code or our books, please create a new discussion: https://github.com/builderbook/builderbook/discussions 
-
--->

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,9 +1,7 @@
 <!-- Before creating your issue, please read the following:
 
-(1) Are you reporting a bug in the code? 
-If yes, please proceed with creating an issue.
+(1) To report a bug in the code, please proceed with creating an issue.
 
-(2) Are you asking a general question or sharing a suggestion about the code or our books? 
-If yes, please create a new discussion item: https://github.com/builderbook/builderbook/discussions 
+(2) To ask a general question or share a suggestion about the code or our books, please create a new discussion: https://github.com/builderbook/builderbook/discussions 
 
 -->

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
   "git.enableSmartCommit": true,
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-  "eslint.enable": true,
   "eslint.alwaysShowStatus": true,
   "eslint.validate": [
     "javascript",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,8 @@
   "git.enableSmartCommit": true,
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "eslint.enable": true,
+  "eslint.format.enable": true,
   "eslint.alwaysShowStatus": true,
   "eslint.validate": [
     "javascript",
@@ -84,5 +86,9 @@
       "directory": "./book/1-end/",
       "changeProcessCWD": true
     },
+    {
+      "directory": "./book/1-begin/",
+      "changeProcessCWD": true
+    }
   ],
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Builder Book
 
-Open source web app to self-publish and sell books or other online content (`builderbook` directory of this repository). If you are book's reader, you will work `book` directory.
+Open source web app to self-publish and sell books or other online content (`builderbook` directory of this repository). If you are a reader of our book, you will work in the `book` directory.
 
 We've used this `builderbook` project to build:
 - [Builder Book](https://builderbook.org) - learn how to build full-stack web apps from scratch
@@ -49,12 +49,12 @@ The main use cases for this project, besides learning, are:
 - [Project structure](#project-structure)
 
 ## Showcase
-Check out projects built with the help of this open source app. Feel free to add your own project by creating a pull request.
+Check out projects built with the help of this open source app.
 - [SaaS boilerplate app](https://github.com/async-labs/saas-by-async): Open source web app that saves you weeks of work when building your own SaaS product. 
 - [Async](https://async-await.com/): asynchronous communication and project management tool for small teams of software engineers.
 - [Retaino](https://retaino.com) by [Earl Lee](https://github.com/earllee) : Save, annotate, review, and share great web content. Receive smart email digests to retain key information.
 - https://michaelstromer.nyc by [Michael Stromer](https://github.com/Maelstroms38): Books and articles by Michael Stromer.
-- Email us to be added here!
+- Email us or submit a pull request to be added here!
 
 ## Run locally
 - Clone the project and run `yarn` to add packages.
@@ -265,7 +265,7 @@ We also specified styles for all content inside a `<body>` element:
 
 ## Deploy to Heroku
 
-In this section we will learn how to deploy our app to [Heroku cloud](https://www.heroku.com/home). We will deploy our React-Next-Express app to lightweight Heroku container called [dyno](https://www.heroku.com/dynos).
+In this section, we will learn how to deploy our app to [Heroku cloud](https://www.heroku.com/home). We will deploy our React-Next-Express app to lightweight Heroku container called [dyno](https://www.heroku.com/dynos).
 
 Instructions are for app located at `/book/8-end`.
 Adjust route if you are deploying app from the root of this public repo.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We've used this `builderbook` project to build:
 
 ## What can I learn from this project?
 
-You will learn how to structure your project and build many intetnal and external API infrastructures.
+You will learn how to structure your project and build many internal and external API infrastructures.
 
 On the browser, the main technologies you will learn are: Next.js, React.js, Material-UI.
 On the server, the main technologies you will learn are: Next.js, Node.js, Express.js, Mongoose.js, MongoDB database.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Check out projects built with the help of this open source app. Feel free to add
 ## Run locally
 - Clone the project and run `yarn` to add packages.
 - Before you start the app, create a `.env` file at the app's root. This file must have values for some env variables specified below.
-  - To get `MONGO_URL_TEST`, we recommend a [free MongoDB at MongoDB Atlas](https://docs.mongodb.com/manual/tutorial/atlas-free-tier-setup/) (to be updated soon with MongoDB Atlas, see [issue](https://github.com/builderbook/builderbook/issues/138)).
+  - To get `MONGO_URL_TEST`, we recommend a [free MongoDB at MongoDB Atlas](https://docs.mongodb.com/manual/tutorial/atlas-free-tier-setup/) (to be updated soon with MongoDB Atlas, see [issue](https://github.com/async-labs/builderbook/issues/138)).
   - Get `GOOGLE_CLIENTID` and `GOOGLE_CLIENTSECRET` by following [official OAuth tutorial](https://developers.google.com/identity/sign-in/web/sign-in#before_you_begin).
 
     Important: For Google OAuth app, callback URL is: http://localhost:8000/oauth2callback <br/>
@@ -178,7 +178,7 @@ For example, in our `book` page, we wrote this single inline style:
   ...
 </p>
 ```
-[See usage](https://github.com/builderbook/builderbook/blob/49116676e0894fcf00c33d208a284359b30f12bb/pages/book.js#L48)
+[See usage](https://github.com/async-labs/builderbook/blob/49116676e0894fcf00c33d208a284359b30f12bb/pages/book.js#L48)
 
 
 ### Reusable style for multiple elements within single page or component
@@ -197,7 +197,7 @@ const styleExcerpt = {
 </p>
 
 ```
-[See usage](https://github.com/builderbook/builderbook/blob/49116676e0894fcf00c33d208a284359b30f12bb/pages/tutorials.js#L14)
+[See usage](https://github.com/async-labs/builderbook/blob/49116676e0894fcf00c33d208a284359b30f12bb/pages/tutorials.js#L14)
 
 
 ### Reusable/importable style for multiple pages or components
@@ -214,7 +214,7 @@ module.exports = {
   styleH1,
 };
 ```
-[See usage](https://github.com/builderbook/builderbook/blob/04c6cf78bee42455d48ef3466d868f2196381a57/components/SharedStyles.js#L48)
+[See usage](https://github.com/async-labs/builderbook/blob/04c6cf78bee42455d48ef3466d868f2196381a57/components/SharedStyles.js#L48)
 
 We then imported `styleH1` into our `book` page, as well as our `index` page, and applied the style to a `<h1>` element:
 ```
@@ -226,7 +226,7 @@ import {
   ...
 </h1>
 ```
-[See usage](https://github.com/builderbook/builderbook/blob/49116676e0894fcf00c33d208a284359b30f12bb/pages/book.js#L13)
+[See usage](https://github.com/async-labs/builderbook/blob/49116676e0894fcf00c33d208a284359b30f12bb/pages/book.js#L13)
 
 
 ### Global style for all pages in application
@@ -244,7 +244,7 @@ Create your style in `pages/_document.js`. For example, we specified a style for
   `}
 </style>
 ```
-[See usage](https://github.com/builderbook/builderbook/blob/49116676e0894fcf00c33d208a284359b30f12bb/pages/_document.js#L51)
+[See usage](https://github.com/async-labs/builderbook/blob/49116676e0894fcf00c33d208a284359b30f12bb/pages/_document.js#L51)
 
 We also specified styles for all content inside a `<body>` element:
 ```
@@ -260,7 +260,7 @@ We also specified styles for all content inside a `<body>` element:
 >
 </body>
 ```
-[See usage](https://github.com/builderbook/builderbook/blob/49116676e0894fcf00c33d208a284359b30f12bb/pages/_document.js#L96)
+[See usage](https://github.com/async-labs/builderbook/blob/49116676e0894fcf00c33d208a284359b30f12bb/pages/_document.js#L96)
 
 
 ## Deploy to Heroku
@@ -298,18 +298,18 @@ Let's go step by step.
     ![image](https://user-images.githubusercontent.com/10218864/54558544-417c9700-497b-11e9-8885-6fdfde21c747.png)
 
 3. As you can see from the above screenshot, you have two options. You can deploy the app directly from your local machine using Heroku CLI or directly from GitHub.
-    In this tutorial, we will deploy a `builderbook/builderbook/book/8-end` app from our public [builderbook/builderbook](https://github.com/builderbook/builderbook) repo hosted on GitHub. Deploying from a private repo will be a similar process.
+    In this tutorial, we will deploy a `async-labs/builderbook/book/8-end` app from our public [async-labs/builderbook](https://github.com/async-labs/builderbook) repo hosted on GitHub. Deploying from a private repo will be a similar process.
     
-    Deploying from GitHub has a few advantages. Heroku uses git to track changes in a codebase. It's possible to deploy app from the local machine using Heroku CLI, however you have to create a [Git repo](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository) for `builderbook/builderbook/book/8-end` with `package.json` file at the root level. A first advantage is that we can deploy from a non-root folder using GitHub instead of Heroku CLI.
+    Deploying from GitHub has a few advantages. Heroku uses git to track changes in a codebase. It's possible to deploy app from the local machine using Heroku CLI, however you have to create a [Git repo](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository) for `async-labs/builderbook/book/8-end` with `package.json` file at the root level. A first advantage is that we can deploy from a non-root folder using GitHub instead of Heroku CLI.
     
     A second advantage is automation, later on you can create a branch that automatically deploy every new commit to Heroku. For example, we have a [deploy branch](https://github.com/async-labs/saas/tree/deploy) for our demo for [SaaS boilerplate](https://github.com/async-labs/saas/). When we commit to `master` branch - there is no new deployment, when we commit to `deploy` branch - new change is automatically deployed to Heroku app.
 
     Let's set up deploying from GitHub. On `Deploy` tab of your Heroku app at Heroku dashboard, click <b>Connect to GitHub</b>, then search for your repo, then click <b>Connect</b> next to the name of the proper repo:
     ![image](https://user-images.githubusercontent.com/10218864/54560210-09775300-497f-11e9-9027-2e3850ec7ff1.png)
 
-    If successful, you will see green text `Connected` and be offered to select a branch and deploy app automatically or manually. Automatic deployment will deploy every new commit, manual deployment requires you to manually click on <b>Deploy Branch</b> button. For simplicity, we will deploy manually from `master` branch of our `builderbook/builderbook` repo.
+    If successful, you will see green text `Connected` and be offered to select a branch and deploy app automatically or manually. Automatic deployment will deploy every new commit, manual deployment requires you to manually click on <b>Deploy Branch</b> button. For simplicity, we will deploy manually from `master` branch of our `async-labs/builderbook` repo.
 
-    Before we perform a manual deployment via GitHub, we need Heroku to run some additional code while app is being deploying. Firstly, we need to tell Heroku that `8-end` app in the `builderbook/builderbook` repo is not at the root level, it's actually nested at `/book/8-end`. Secondly, Heroku needs to know that our app is Node.js app so Heroku finds `package.json` file, properly installs dependencies and runs proper scripts (such as `build` and `start` scripts from `package.json`). To achieve this, we need to add so called `buildpacks` to our Heroku app. Click `Settings` tab, scroll to `Buildpacks` section and click purple <b>Add buildpack</b> button:
+    Before we perform a manual deployment via GitHub, we need Heroku to run some additional code while app is being deploying. Firstly, we need to tell Heroku that `8-end` app in the `async-labs/builderbook` repo is not at the root level, it's actually nested at `/book/8-end`. Secondly, Heroku needs to know that our app is Node.js app so Heroku finds `package.json` file, properly installs dependencies and runs proper scripts (such as `build` and `start` scripts from `package.json`). To achieve this, we need to add so called `buildpacks` to our Heroku app. Click `Settings` tab, scroll to `Buildpacks` section and click purple <b>Add buildpack</b> button:
     ![image](https://user-images.githubusercontent.com/10218864/54561192-50fede80-4981-11e9-976a-c3d7c88527ec.png)
 
     Add two buildpacks, first is `https://github.com/timanovsky/subdir-heroku-buildpack` and second is `heroku/nodejs`:
@@ -409,7 +409,7 @@ Book-detail page for Admin user:
 - Stripe
 - MailChimp
 
-Check out [package.json](https://github.com/builderbook/builderbook/builderbook/blob/master/package.json).
+Check out [package.json](https://github.com/async-labs/builderbook/builderbook/blob/master/package.json).
 
 ## Docker
 - Install Docker and Docker Compose
@@ -420,7 +420,7 @@ Check out [package.json](https://github.com/builderbook/builderbook/builderbook/
 ## Contributing
 We welcome suggestions and bug reports via issues and and pull requests.
 
-By participating in this project, you are expected to uphold Builder Book's [Code of Conduct](https://github.com/builderbook/builderbook/blob/master/CODE-OF-CONDUCT.md).
+By participating in this project, you are expected to uphold Builder Book's [Code of Conduct](https://github.com/async-labs/builderbook/blob/master/CODE-OF-CONDUCT.md).
 
 Want to support this project? Sign up at [async](https://async-await.com) and/or buy our [books](https://builderbook.org), which teach you how to build web apps from scratch. Also check out our open source [SaaS boilerplate](https://github.com/async-labs/saas).
 
@@ -433,7 +433,7 @@ Want to support this project? Sign up at [async](https://async-await.com) and/or
 You can contact us at team@builderbook.org
 
 ## License
-All code in this repository is provided under the [MIT License](https://github.com/builderbook/builderbook/blob/master/LICENSE.md).
+All code in this repository is provided under the [MIT License](https://github.com/async-labs/builderbook/blob/master/LICENSE.md).
 
 
 ## Project structure

--- a/book/1-begin/.eslintrc.js
+++ b/book/1-begin/.eslintrc.js
@@ -1,0 +1,55 @@
+module.exports = {
+  parser: "babel-eslint",
+  extends: ["airbnb", "plugin:prettier/recommended"],
+  env: {
+    browser: true,
+    jest: true,
+  },
+  plugins: ["react", "jsx-a11y", "import", "prettier"],
+  rules: {
+    "prettier/prettier": [
+      "error",
+      {
+        singleQuote: true,
+        trailingComma: "all",
+        arrowParens: "always",
+        printWidth: 100,
+        semi: true,
+      },
+    ],
+    camelcase: "off",
+    "no-underscore-dangle": ["error", { allow: ["_id"] }],
+    "no-mixed-operators": "off",
+    "prefer-arrow-callback": "error",
+    "prefer-destructuring": [
+      "error",
+      {
+        VariableDeclarator: {
+          array: false,
+          object: true,
+        },
+        AssignmentExpression: {
+          array: true,
+          object: false,
+        },
+      },
+      {
+        enforceForRenamedProperties: false,
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "jsx-a11y/anchor-is-valid": "off",
+    "react/jsx-wrap-multilines": "off",
+    "react/destructuring-assignment": "off",
+    "react/no-danger": "off",
+    "react/jsx-one-expression-per-line": "off",
+    "react/jsx-props-no-spreading": "off",
+    "react/react-in-jsx-scope": "off",
+    "react/jsx-filename-extension": [
+      "error",
+      {
+        extensions: [".jsx"],
+      },
+    ],
+  },
+};

--- a/book/1-begin/.npmrc
+++ b/book/1-begin/.npmrc
@@ -1,0 +1,1 @@
+registry = 'https://registry.npmjs.org/'

--- a/book/1-begin/package.json
+++ b/book/1-begin/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "lint": "eslint '**/*.jsx'"
   },
   "dependencies": {
     "@material-ui/core": "4.11.0",
@@ -15,5 +16,16 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "babel-eslint": "^10.1.0",
+    "eslint": "^6.7.2",
+    "eslint-config-airbnb": "^18.2.1",
+    "eslint-config-prettier": "^6.15.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-react": "^7.21.5",
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "prettier": "^2.2.1"
+  }
 }

--- a/book/1-begin/pages/test.jsx
+++ b/book/1-begin/pages/test.jsx
@@ -1,0 +1,4 @@
+[1, 2, 3].map((x) => {
+  const y = x + 1;
+  return x * y;
+});

--- a/book/1-end/.eslintrc.js
+++ b/book/1-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/2-begin/.eslintrc.js
+++ b/book/2-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/2-end/.eslintrc.js
+++ b/book/2-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/2-end/components/Header.jsx
+++ b/book/2-end/components/Header.jsx
@@ -11,7 +11,7 @@ import { styleToolbar } from './SharedStyles';
 const optionsMenu = [
   {
     text: 'Got question?',
-    href: 'https://github.com/builderbook/builderbook/issues',
+    href: 'https://github.com/async-labs/builderbook/issues',
   },
   {
     text: 'Log out',

--- a/book/3-begin/.eslintrc.js
+++ b/book/3-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/3-begin/components/Header.jsx
+++ b/book/3-begin/components/Header.jsx
@@ -11,7 +11,7 @@ import { styleToolbar } from './SharedStyles';
 const optionsMenu = [
   {
     text: 'Got question?',
-    href: 'https://github.com/builderbook/builderbook/issues',
+    href: 'https://github.com/async-labs/builderbook/issues',
   },
   {
     text: 'Log out',

--- a/book/3-end/.eslintrc.js
+++ b/book/3-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/3-end/components/Header.jsx
+++ b/book/3-end/components/Header.jsx
@@ -11,7 +11,7 @@ import { styleToolbar } from './SharedStyles';
 const optionsMenu = [
   {
     text: 'Got question?',
-    href: 'https://github.com/builderbook/builderbook/issues',
+    href: 'https://github.com/async-labs/builderbook/issues',
   },
   {
     text: 'Log out',

--- a/book/4-begin/.eslintrc.js
+++ b/book/4-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/4-begin/components/Header.jsx
+++ b/book/4-begin/components/Header.jsx
@@ -10,7 +10,7 @@ import { styleToolbar } from './SharedStyles';
 const optionsMenu = [
   {
     text: 'Got question?',
-    href: 'https://github.com/builderbook/builderbook/issues',
+    href: 'https://github.com/async-labs/builderbook/issues',
   },
   {
     text: 'Log out',

--- a/book/4-end/.eslintrc.js
+++ b/book/4-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/4-end/components/Header.jsx
+++ b/book/4-end/components/Header.jsx
@@ -11,7 +11,7 @@ import { styleToolbar } from './SharedStyles';
 const optionsMenu = [
   {
     text: 'Got question?',
-    href: 'https://github.com/builderbook/builderbook/issues',
+    href: 'https://github.com/async-labs/builderbook/issues',
   },
   {
     text: 'Log out',

--- a/book/5-begin/.eslintrc.js
+++ b/book/5-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/5-begin/components/Header.jsx
+++ b/book/5-begin/components/Header.jsx
@@ -10,7 +10,7 @@ import { styleToolbar } from './SharedStyles';
 const optionsMenu = [
   {
     text: 'Got question?',
-    href: 'https://github.com/builderbook/builderbook/issues',
+    href: 'https://github.com/async-labs/builderbook/issues',
   },
   {
     text: 'Log out',

--- a/book/5-end/.eslintrc.js
+++ b/book/5-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/5-end/components/Header.jsx
+++ b/book/5-end/components/Header.jsx
@@ -11,7 +11,7 @@ import { styleToolbar } from './SharedStyles';
 const optionsMenu = [
   {
     text: 'Got question?',
-    href: 'https://github.com/builderbook/builderbook/issues',
+    href: 'https://github.com/async-labs/builderbook/issues',
   },
   {
     text: 'Log out',

--- a/book/6-begin/.eslintrc.js
+++ b/book/6-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/6-begin/components/Header.jsx
+++ b/book/6-begin/components/Header.jsx
@@ -11,7 +11,7 @@ import { styleToolbar } from './SharedStyles';
 const optionsMenu = [
   {
     text: 'Got question?',
-    href: 'https://github.com/builderbook/builderbook/issues',
+    href: 'https://github.com/async-labs/builderbook/issues',
   },
   {
     text: 'Log out',

--- a/book/6-end/.eslintrc.js
+++ b/book/6-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/7-begin/.eslintrc.js
+++ b/book/7-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/7-end/.eslintrc.js
+++ b/book/7-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/8-begin/.eslintrc.js
+++ b/book/8-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/8-end/.eslintrc.js
+++ b/book/8-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/8-end/components/customer/BuyButton.jsx
+++ b/book/8-end/components/customer/BuyButton.jsx
@@ -42,7 +42,7 @@ const defaultProps = {
   redirectToCheckout: false,
 };
 
-class BuyButton extends React.PureComponent {
+class BuyButton extends React.Component {
   componentDidMount() {
     if (this.props.redirectToCheckout) {
       this.handleCheckoutClick();

--- a/book/8-end/server/server.js
+++ b/book/8-end/server/server.js
@@ -46,15 +46,6 @@ app.prepare().then(async () => {
 
   server.use(express.json());
 
-  // give all Nextjs's request to Nextjs server
-  server.get('/_next/*', (req, res) => {
-    handle(req, res);
-  });
-
-  server.get('/static/*', (req, res) => {
-    handle(req, res);
-  });
-
   const MongoStore = mongoSessionStore(session);
   const sess = {
     name: process.env.SESSION_NAME,

--- a/book/9-begin/.eslintrc.js
+++ b/book/9-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/9-begin/components/customer/BuyButton.jsx
+++ b/book/9-begin/components/customer/BuyButton.jsx
@@ -42,7 +42,7 @@ const defaultProps = {
   redirectToCheckout: false,
 };
 
-class BuyButton extends React.PureComponent {
+class BuyButton extends React.Component {
   componentDidMount() {
     if (this.props.redirectToCheckout) {
       this.handleCheckoutClick();

--- a/book/9-begin/server/server.js
+++ b/book/9-begin/server/server.js
@@ -46,15 +46,6 @@ app.prepare().then(async () => {
 
   server.use(express.json());
 
-  // give all Nextjs's request to Nextjs server
-  server.get('/_next/*', (req, res) => {
-    handle(req, res);
-  });
-
-  server.get('/static/*', (req, res) => {
-    handle(req, res);
-  });
-
   const MongoStore = mongoSessionStore(session);
   const sess = {
     name: process.env.SESSION_NAME,

--- a/book/9-end/.eslintrc.js
+++ b/book/9-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/9-end/components/customer/BuyButton.jsx
+++ b/book/9-end/components/customer/BuyButton.jsx
@@ -42,7 +42,7 @@ const defaultProps = {
   redirectToCheckout: false,
 };
 
-class BuyButton extends React.PureComponent {
+class BuyButton extends React.Component {
   componentDidMount() {
     if (this.props.redirectToCheckout) {
       this.handleCheckoutClick();

--- a/book/9-end/server/server.js
+++ b/book/9-end/server/server.js
@@ -54,10 +54,6 @@ app.prepare().then(async () => {
     handle(req, res);
   });
 
-  server.get('/static/*', (req, res) => {
-    handle(req, res);
-  });
-
   const MongoStore = mongoSessionStore(session);
   const sess = {
     name: process.env.SESSION_NAME,

--- a/builderbook/.eslintrc.js
+++ b/builderbook/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/builderbook/components/customer/BuyButton.jsx
+++ b/builderbook/components/customer/BuyButton.jsx
@@ -42,7 +42,7 @@ const defaultProps = {
   redirectToCheckout: false,
 };
 
-class BuyButton extends React.PureComponent {
+class BuyButton extends React.Component {
   componentDidMount() {
     if (this.props.redirectToCheckout) {
       this.handleCheckoutClick();

--- a/builderbook/server/models/EmailTemplate.js
+++ b/builderbook/server/models/EmailTemplate.js
@@ -51,7 +51,7 @@ async function insertTemplates() {
         <p>
           If you have any questions while reading the book,
           please fill out an issue on
-          <a href="https://github.com/builderbook/builderbook/issues" target="blank">Github</a>.
+          <a href="https://github.com/async-labs/builderbook/issues" target="blank">Github</a>.
         </p>
 
         Kelly & Timur, Team Builder Book

--- a/builderbook/server/server.js
+++ b/builderbook/server/server.js
@@ -53,10 +53,6 @@ app.prepare().then(async () => {
     handle(req, res);
   });
 
-  server.get('/static/*', (req, res) => {
-    handle(req, res);
-  });
-
   const MongoStore = mongoSessionStore(session);
   const sess = {
     name: process.env.SESSION_NAME,


### PR DESCRIPTION
Items added to the extends array in the `.eslintrc` config, will overwrite or extend items proceeding it. This is resulting in the removal of some of the more stricter airbnb rules which are discussed in chapter 1. See example below:

> Create a pages/test.jsx file inside your 1-begin folder, then paste the following code:
>
> [1, 2, 3].map(function (x) {
  const y = x + 1;
  return x * y;
});

Currently saving this file with the current ordering of extends in `.eslintrc` will not result in an arrow function and the `prefer-arrow-callback` rule will not be enforced.

It looks like the order will need to be reversed if we want to prioritise the `airbnb` eslint rules, as implied in the first chapter. Alternatively we could add the `prefer-arrow-callback` rule manually as if we reverse the ordering it will also result in prettier errors for other files, such as `pages/_document.jsx`.

![Screenshot 2020-12-18 at 10 04 21](https://user-images.githubusercontent.com/8799141/102601765-83baa580-4118-11eb-851d-e3e76d4dcb77.png)